### PR TITLE
Make sure multiple DNS servers set same serial within one playbook run

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -16,6 +16,11 @@
   notify:
     - Restart gdnsd
 
+- name: Generate serial
+  set_fact:
+    gdnsd__fact_zone_serial: '{{ ansible_date_time.epoch }}'
+  run_once: True
+
 - name: Read forward zone hashes
   shell: 'grep "^; Hash:" /etc/gdnsd/zones/{{ item.domain }} || true'
   changed_when: False

--- a/templates/etc/gdnsd/zones/forward_zone.j2
+++ b/templates/etc/gdnsd/zones/forward_zone.j2
@@ -50,7 +50,7 @@
 {%     if _hash_serial and _hash_serial[0] == _zone['hash'] %}
 {%       set _ = _zone.update({'serial': _hash_serial[1]}) %}
 {%     else %}
-{%       set _ = _zone.update({'serial': ansible_date_time.epoch}) %}
+{%       set _ = _zone.update({'serial': gdnsd__fact_zone_serial}) %}
 {%     endif %}
 {%   endif %}
 {% endfor %}

--- a/templates/etc/gdnsd/zones/reverse_zone.j2
+++ b/templates/etc/gdnsd/zones/reverse_zone.j2
@@ -66,7 +66,7 @@
 {%     if _hash_serial and _hash_serial[0] == _zone['hash'] %}
 {%       set _ = _zone.update({'serial': _hash_serial[1]}) %}
 {%     else %}
-{%       set _ = _zone.update({'serial': ansible_date_time.epoch}) %}
+{%       set _ = _zone.update({'serial': gdnsd__fact_zone_serial}) %}
 {%     endif %}
 {%   endif %}
 {% endfor %}


### PR DESCRIPTION
So far, when zone files are generated on multiple DNS servers each will update the serial according the current time of the zone file generation. This will normally result in different serials for the same zone file. With this PR, the serial is generated once for a playbook run and then reused for every zone which is updated.

If two servers are updated with the same zone data independently, this will still result in different serials. However, it will help zone updates which will run on all DNS servers concurrently from within the same playbook execution.

Obviously this mechanism won't detect differing zone data for the same zone on different servers. You have to make sure that the zone configuration in the Ansible inventory is identical for all servers, which are updated at once.
